### PR TITLE
colored mushrooms & server changes.

### DIFF
--- a/chat_history.json
+++ b/chat_history.json
@@ -1,1 +1,0 @@
-{"global":[],"the mushroom":[],"pretty fly (for a fungi)":[]}

--- a/pub/client.js
+++ b/pub/client.js
@@ -1,6 +1,8 @@
 /** Socket.io client-side setup */
 const socket = io();
 
+const mushroom_icon_size = 20;
+
 /** Vue app setup */
 Vue.createApp({
     data() {
@@ -14,7 +16,8 @@ Vue.createApp({
 
             /** Messaging */
             text: "", // Input text for submitting new messages
-            editText: "" // Input text for editing messages
+            editText: "", // Input text for editing messages
+
         };
     },
     created() {
@@ -40,13 +43,13 @@ Vue.createApp({
          *    add: add them to the list of users
          *    remove: remove them from the list of users
          */
-        socket.on("updateUsers", (action, userName) => {
+        socket.on("updateUsers", (action, username, icon_color) => {
             switch (action) {
                 case "add":
-                    this.users.push(userName);
+                    this.users.push({username: username, icon_color: icon_color});
                     break;
                 case "remove":
-                    this.users.splice(this.users.findIndex(user => user == userName), 1);
+                    this.users.splice(this.users.findIndex(user => user.username == username), 1);
                     break;
             }
         });
@@ -57,7 +60,6 @@ Vue.createApp({
          *    delete: use that message's ID to delete a message from the chat history 
          */
         socket.on("updateChat", (action, message) => {
-            console.log(this.history);
             switch (action) {
                 case "new":
                     this.history.push(message);
@@ -136,6 +138,18 @@ Vue.createApp({
         check_for_mention(str) {
             if(str.includes('@' + this.author)) return true;
             return false;
+        },
+
+        /*
+         * Each icon color filter has a unique id based on the index of the message being rendered
+         * we need to use this or it will only apply one filter all mushrooms.
+         */
+        get_icon_color_filter(id){
+            return {
+                '-webkit-filter': 'url(#picked-filter' + id + ')',
+                'filter': 'url(#picked-filter' + id + ')',
+                'font-size': mushroom_icon_size + 'px',
+            }
         }
-    }
+    },
 }).mount('#app');

--- a/pub/index.html
+++ b/pub/index.html
@@ -27,8 +27,16 @@
             <p></p>
         </div>
         <div id="chat-box">
-            <div v-for="data in history">
+            <div v-for="(data, idx) in history">
                 <div class="message-meta">
+                    <div>
+                        <svg height="100" width="100">
+                            <filter :id="'picked-filter' + idx">
+                                <feColorMatrix type="matrix" :values="data.icon_color"/>
+                            </filter>
+                        </svg>
+                        <p :style="get_icon_color_filter(idx)">🍄</p>
+                    </div>
                     <p class="author">{{ data.author }}</p>
                     <p>{{ new Date(data.timestamp).toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'}) }} </p>
                     <div v-if="data.author == author">

--- a/pub/style.css
+++ b/pub/style.css
@@ -8,6 +8,7 @@ html {
     overflow-y: scroll;
 }
 
+
 .message-meta {
     width: 250px;
     display: flex;
@@ -50,4 +51,6 @@ html {
     transition: visibility 0s linear 0s, opacity 0.25s 0s, transform 0.25s;
 }
 
-
+svg {
+    display: none;
+}

--- a/pub/style.css
+++ b/pub/style.css
@@ -52,5 +52,6 @@ html {
 }
 
 svg {
-    display: none;
+    position: absolute;
+    height: 0;
 }

--- a/server.js
+++ b/server.js
@@ -44,6 +44,7 @@ function load_chat_history() {
 
 /** Save local chat history array to file */
 function save_chat_history() {
+    /* @TODO we should ultimately persist users to the file system as well as users shouldn't lose their metadata simply because the server went down. */
     fs.writeFileSync(CHAT_HISTORY_FNAME, JSON.stringify(chatHistory, { type: "application/json;charset=utf-8" }), (err) => {
         if (err) {
             console.log(err);
@@ -51,6 +52,32 @@ function save_chat_history() {
             console.log('Successfuly written to the file!');
         }
     });
+}
+
+/* R G B */
+const mushroom_color_min = 53;
+const mushroom_color_max = 177;
+
+function generate_mushroom_color() {
+    /**
+     * Basically I found a min and max that doesn't tear the icon up, which is what I used here.
+     *
+     * @NOTE the only issue I found is this doesn't play well with firefox so we should use Chrome during our presentation.
+     * Not totally sure why but we're time strapped so I don't really care either.
+     */
+    const r = ((Math.random() * (mushroom_color_max - mushroom_color_min + 1) + mushroom_color_min) / mushroom_color_max);
+    const g = ((Math.random() * (mushroom_color_max - mushroom_color_min + 1) + mushroom_color_min) / mushroom_color_max);
+    const b = ((Math.random() * (mushroom_color_max - mushroom_color_min + 1) + mushroom_color_min) / mushroom_color_max);
+    const a = 1;
+
+    let matrix = `
+                ${r} 0 0 0 0
+                0 ${g} 0 0 0
+                0 0 0 ${b} 0
+                0 0 0 ${a} 0
+            `;
+
+    return matrix;
 }
 
 /* PROCESS EVENTS */
@@ -77,9 +104,24 @@ io.on("connection", (socket) => {
      */
     socket.on("setUserData", (room, username) => {
         socket.join(room);
-        usersList.set(socket.id, username);
+        let user_color = generate_mushroom_color();
+        /**
+         * So pretty much the idea is usernames are unique (they should be). With this they should be the key in the usersList.
+         * This allows the user to "relogin" without losing any of their ability to edit or delete their previous messages
+         * Also this allows the user icon color to persist along with any other metadata
+         */
+        let userExist = usersList.get(username);
+        if(userExist !== undefined)
+        {
+            userExist.socket = socket.id;
+        }
+        else
+        {
+            /* icon color should be stored along with any other metadata we deem fit for the user */
+            usersList.set(username, {socket: socket.id, icon_color: user_color});
+        }
         socket.emit("setRoomHistory", chatHistory[room]);
-        io.emit("updateUsers", "add", username);
+        io.emit("updateUsers", "add", username, user_color);
     });
 
     /** Receive a message from the client, and:
@@ -94,6 +136,7 @@ io.on("connection", (socket) => {
                     text: message.text,
                     editMessage: false,
                     author: message.author,
+                    icon_color: usersList.get(message.author).icon_color, /**< Fetch user icon color */
                     timestamp: Date.now(),
                     id: base64id.generateId()
                 };


### PR DESCRIPTION
Basically I removed chat_history.json as this should be generated per machine for everyone and should not be held in the git repo.
I also changed our key => usernames as we are under the assumption that usernames should be unique. This in turn allows a user to log out and keep their metadata identical to what is was before. Colors persist over login which looks really nice! I think we should store more metadata for the users in the usersList it's handy. We should ideally also store usersList to the filesystem but with time how it is I could care less.

Filters are weird, not all browsers support them but I ran tests on Chrome and it worked fine. Firefox is iffy and it doesn't seem to happy. However, we're short on time so this will do. If you have any questions about meaning or what's happening let me know :) 

I added @rock374  to see if this is what he had in my mind for the changes. 

I think ideally we should just send all the user metadata on a new message associated with the author. We could do something with location such as a country flag of origin or as it's used here with icon colors. This would also allow other random tidbits which are easy to implement